### PR TITLE
[utils][parser] add `compare other props` option

### DIFF
--- a/utils/parser/function-comparator.js
+++ b/utils/parser/function-comparator.js
@@ -1,5 +1,29 @@
+function deepEqual(obj1, obj2) {
+  if (obj1 === obj2) return true;
+
+  if (
+    typeof obj1 !== 'object' ||
+    obj1 === null ||
+    typeof obj2 !== 'object' ||
+    obj2 === null
+  ) {
+    return false;
+  }
+
+  const keys1 = Object.keys(obj1);
+  const keys2 = Object.keys(obj2);
+
+  if (keys1.length !== keys2.length) return false;
+
+  return keys1.every((key) => deepEqual(obj1[key], obj2[key]));
+}
+
 function compare(tree1, tree2, options) {
   const sortArray = (arr) => [...(arr || [])].sort();
+
+  const compareOtherProps = (t1, t2) => {
+    return deepEqual(t1.otherProps, t2.otherProps);
+  };
 
   const compareProps = (t1, t2) => {
     const props1 = sortArray(t1.props);
@@ -38,6 +62,8 @@ function compare(tree1, tree2, options) {
     if (t1.type || t2.type) {
       if (!comparePathNodes(t1, t2)) return false;
     }
+
+    if (options.compare_other_props && !compareOtherProps(t1, t2)) return false;
 
     const children1 = t1.children || [];
     const children2 = t2.children || [];

--- a/utils/parser/index.js
+++ b/utils/parser/index.js
@@ -15,6 +15,9 @@ const options = {
   if_condition: true,
   order: true,
   node_type: true,
+  operators: ['+', '-', '*', '/', '%', '>', '<', '>=', '<='],
+  literals: true,
+  compare_other_props: true,
 };
 
 const functions = extractFunctions(code).functions;
@@ -28,6 +31,8 @@ logFunctionCode(functions2, file2);
 const collecter_options = {
   early_return: options.early_return,
   if_condition: options.if_condition,
+  operators: options.operators,
+  literals: options.literals,
 };
 
 const proptree = collectProps(functions, collecter_options);
@@ -39,6 +44,7 @@ const proptree2 = collectProps(functions2, collecter_options);
 const comaparator_options = {
   order: options.order,
   node_type: options.node_type,
+  compare_other_props: options.compare_other_props,
 };
 // TODO: add series
 const result = functionComparator(proptree, proptree2, comaparator_options);

--- a/utils/parser/props-collector.js
+++ b/utils/parser/props-collector.js
@@ -1,7 +1,7 @@
 const walk = require('acorn-walk');
 
 function makePropstree(func, options) {
-  const rootTree = { props: [], children: [] };
+  const rootTree = { props: [], children: [], otherProps: {} };
 
   let currentContext = rootTree;
   const contextStack = [];
@@ -9,6 +9,7 @@ function makePropstree(func, options) {
   const withContext = (newContext, callback) => {
     if (!newContext.children) newContext.children = [];
     if (!newContext.props) newContext.props = [];
+    if (!newContext.otherProps) newContext.otherProps = {};
     contextStack.push(currentContext);
     currentContext = newContext;
     callback();
@@ -30,8 +31,8 @@ function makePropstree(func, options) {
         type: 'if',
         props: [],
         paths: {
-          true: { props: [], children: [] },
-          false: { props: [], children: [] },
+          true: { props: [], children: [], otherProps: {} },
+          false: { props: [], children: [], otherProps: {} },
         },
       };
 
@@ -70,8 +71,8 @@ function makePropstree(func, options) {
         type: 'conditional',
         props: [],
         paths: {
-          true: { props: [], children: [] },
-          false: { props: [], children: [] },
+          true: { props: [], children: [], otherProps: {} },
+          false: { props: [], children: [], otherProps: {} },
         },
       };
 
@@ -93,8 +94,8 @@ function makePropstree(func, options) {
         operator: node.operator,
         props: [],
         paths: {
-          left: { props: [], children: [] },
-          right: { props: [], children: [] },
+          left: { props: [], children: [], otherProps: {} },
+          right: { props: [], children: [], otherProps: {} },
         },
       };
 
@@ -114,7 +115,29 @@ function makePropstree(func, options) {
 
       walk.base.MemberExpression(node, state, c);
     },
+
+    BinaryExpression(node, state, c) {
+      if (options.operators) {
+        const operator = node.operator;
+        if (options.operators.includes(operator))
+          incValue(currentContext.otherProps, operator);
+      }
+
+      walk.base.BinaryExpression(node, state, c);
+    },
+
+    Literal(node, state, c) {
+      if (options.literals) {
+        const literal = node.raw;
+        if (currentContext.otherProps.literals)
+          currentContext.otherProps.literals.push(literal);
+        else currentContext.otherProps.literals = [literal];
+      }
+
+      walk.base.Literal(node, state, c);
+    },
   };
+
   function myWalker(node, state, visitors) {
     state.ancestors.push(node);
     const visitor = visitors[node.type];
@@ -141,6 +164,14 @@ function collectProps(functions, options) {
     };
     return acc;
   }, {});
+}
+
+function incValue(obj, key) {
+  if (obj[key]) {
+    obj[key] += 1;
+  } else {
+    obj[key] = 1;
+  }
 }
 
 module.exports = collectProps;


### PR DESCRIPTION
브랜치가 꼬일까봐 PR로 보내봅니다..!

- +, -, ... 등 Binary Operator 
- string, regex 등의 Literal

를 비교하는 옵션을 추가했어요

3.7.1 jquery.js와 jquery.min.js 기준으로, distinguished가 310개에서 430개로 늘어났어요~!