### PR TITLE
[utils][static] add block type to make safe node ids

### DIFF
--- a/utils/static-analysis/src/abstract/cfg.ts
+++ b/utils/static-analysis/src/abstract/cfg.ts
@@ -330,8 +330,10 @@ function createVisitor(prevId: number, state: CFGState): Visitor {
       // todo
       throw UnsupportedStatementError('FunctionDeclaration');
     },
-    Identifier(node) {
-      return prevId;
+    Identifier(node: acorn.Node) {
+      const identifierNode = node as acorn.Identifier;
+      const id = createNode(state, 'block', identifierNode, [prevId]);
+      return id;
     },
     Literal(node) {
       return prevId;
@@ -585,8 +587,34 @@ function generateIR(ast: acorn.Node) {
   return ir;
 }
 
-async function cfgToDot(graph: CFGState): Promise<string> {
+function removeBlockNodes(graph: CFGState): CFGState {
+  // so dirty and time-consuming ..
   const nodes = graph.nodes;
+  for (const [id, node] of nodes.entries()) {
+    if (node.type === 'block') {
+      const prevIds = node.prev;
+      const nextIds = Array.from(nodes.entries())
+        .filter(([_, n]) => n.prev.includes(id))
+        .map(([_, n]) => n.id);
+      for (const p of prevIds) {
+        for (const n of nextIds) {
+          addEdge(graph, p, n);
+        }
+      }
+      nodes.delete(id);
+    } else {
+      const prevIds = node.prev.filter((id) => {
+        const n = nodes.get(id);
+        return n && n.type !== 'block';
+      });
+      nodes.set(id, { ...node, prev: prevIds });
+    }
+  }
+  return { ...graph, nodes };
+}
+
+async function cfgToDot(graph: CFGState): Promise<string> {
+  const nodes = removeBlockNodes(graph).nodes;
   let dotString = 'digraph CFG {\n';
   dotString += '  rankdir=TB;\n';
   dotString += '  node [shape=box, style=filled, fontname="Arial"];\n\n';

--- a/utils/static-analysis/src/utils/types.ts
+++ b/utils/static-analysis/src/utils/types.ts
@@ -45,7 +45,8 @@ export interface CFGNode {
     | 'prop'
     | 'update_prop'
     | 'exit'
-    | 'end';
+    | 'end'
+    | 'block';
   node: Node | null;
   prev: number[];
 }


### PR DESCRIPTION
identifier 처럼 cfg에서 의미를 가지지 않는 node가 `prevId`를 리턴하면 아래와 같은 오류가 발생합니다

IR에서 `_.css = _;`와 `_.offset = _;` 이 생기면 안되는데 생겼습니다..
이유는 할당되는 노드가 Identifier여서 prevId인 prop의 id를 받아버렸기 때문입니다..

그래서 빈 Node여도 일단 node를 만드는 방식으로 해결해보았습니다..

하지만 지금 생각해보니 identifier일 경우 Node를 만들지 말고 currentId만 늘려주면 어떨까 싶긴 하네요..

@taxor03 님의 의견에 따르겠습니다!


```js
  var curPosition,
    curLeft,
    curCSSTop,
    curTop,
    curOffset,
    curCSSLeft,
    calculatePosition,
    position = jQuery.css(elem, 'position'),
    curElem = jQuery(elem),
    props = {};
  if (position === 'static') {
    elem.style.position = 'relative';
  }
  curOffset = curElem.offset();
  curCSSTop = jQuery.css(elem, 'top');
  curCSSLeft = jQuery.css(elem, 'left');
  calculatePosition =
    (position === 'absolute' || position === 'fixed') &&
    (curCSSTop + curCSSLeft).indexOf('auto') > -1;
  if (calculatePosition) {
    curPosition = curElem.position();
    curTop = curPosition.top;
    curLeft = curPosition.left;
  } else {
    curTop = parseFloat(curCSSTop) || 0;
    curLeft = parseFloat(curCSSLeft) || 0;
  }
  if (isFunction(options)) {
    options = options.call(elem, i, jQuery.extend({}, curOffset));
  }
  if (options.top != null) {
    props.top = options.top - curOffset.top + curTop;
  }
  if (options.left != null) {
    props.left = options.left - curOffset.left + curLeft;
  }
  if ('using' in options) {
    options.using.call(elem, props);
  } else {
    curElem.css(props);
  }
```

아래 IR에  `_.css = _;`와 `_.offset = _;`이 있으면 안 됨
```
_.css;
_ ? (_.style;
_.position;
_.position = _;
_.offset;
_.css;
_.offset = _;
_.css;
_ ? (_ ? (_.indexOf;
_.css = _;
_ ? (_.position;
_.top;
_.position = _;
_.left;
_ ? (_.call;
_.extend;
_.top;
_ ? (_.top;
_.top;
_.top;
_.top = _;
_.left;
_ ? (_.left;
_.left;
_.left;
_.left = _;
_ ? (_.using;
_.call;
) : (_.css);
) : ();
) : ();
) : ();
) : (_ ? (_ ? () : ()) : ());
) : ()) : ();
) : ();
```